### PR TITLE
Support for Opera on Linux and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ Pronounced `Tie-tree-yes`.
         </tr>
         <tr>
             <td><img src="svg/browser/opera.svg" width="60"></td>
-            <td><img src="svg/not-implemented.svg" width="60"></td>
-            <td><img src="svg/not-implemented.svg" width="60"></td>
+            <td><img src="svg/supported.svg" width="60"></td>
+            <td><img src="svg/supported.svg" width="60"></td>
             <td><img src="svg/not-implemented.svg" width="60"></td>
         </tr>
         <tr>
             <td><img src="svg/browser/opera-gx.svg" width="60"></td>
             <td><img src="svg/not-implemented.svg" width="60"></td>
-            <td><img src="svg/not-implemented.svg" width="60"></td>
+            <td><img src="svg/not-supported.svg" width="60"></td>
             <td><img src="svg/not-implemented.svg" width="60"></td>
         </tr>
         <tr>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,3 +27,19 @@ RUN addgroup --gid ${gid} $USERNAME \
     $USERNAME
 
 WORKDIR /home/${user}
+
+FROM ubuntu:25.04 AS base_ubuntu
+
+ARG user
+ARG uid
+ARG gid
+
+ENV USERNAME=${user}
+
+RUN groupadd -g ${gid} $USERNAME
+RUN userdel ubuntu && useradd $USERNAME -u ${uid} -g ${gid} -m -s /bin/bash
+
+RUN  apt-get update \
+    && apt-get install -y wget gnupg2 dirmngr ca-certificates software-properties-common apt-transport-https curl
+
+WORKDIR /home/${user}

--- a/docker/chrome/Dockerfile
+++ b/docker/chrome/Dockerfile
@@ -10,5 +10,4 @@ ENV USERNAME=${user}
 ENV CHROME_CONFIG_HOME /home/${user}/.google-chrome
 USER ${user}
 
-# TODO: enable sandbox
 CMD ["chromium", "--no-sandbox"]

--- a/docker/opera/Dockerfile
+++ b/docker/opera/Dockerfile
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 Robert Wesner
+
+FROM titryes/base-ubuntu
+
+
+RUN curl -fsSL https://deb.opera.com/archive.key | gpg --dearmor | tee /usr/share/keyrings/opera.gpg > /dev/null
+RUN echo deb [arch=amd64 signed-by=/usr/share/keyrings/opera.gpg] https://deb.opera.com/opera-stable/ stable non-free | tee /etc/apt/sources.list.d/opera.list
+RUN apt-get update && apt-get -y install opera-stable
+
+ARG user
+ENV USERNAME=${user}
+USER ${user}
+
+CMD ["opera", "--no-sandbox"]

--- a/run.rb
+++ b/run.rb
@@ -18,18 +18,29 @@ puts(
 )
 
 # TODO: check for docker being installed
-# TODO: check for Xorg
 
 puts("/!\\ Make sure to have mounted all partitions you intend to scan.\n\n")
 
 puts("Running setup...")
+puts("Creating alpine base image...")
 system(
   <<'SHELL'
   docker build --build-arg user=$USER --build-arg uid=$(id -u) --build-arg gid=$(id -g) \
-      -t titryes/base \
-      docker > /dev/null 2>&1
+    --target base \
+    -t titryes/base \
+    docker > /dev/null 2>&1
 SHELL
 )
+puts("Creating ubuntu base image...")
+system(
+  <<'SHELL'
+  docker build --build-arg user=$USER --build-arg uid=$(id -u) --build-arg gid=$(id -g) \
+    --target base_ubuntu \
+    -t titryes/base-ubuntu \
+    docker > /dev/null # 2>&1
+SHELL
+)
+puts("Creating Xorg configuration...")
 system("xauth nlist $DISPLAY | sed -e \"s/^..../ffff/\" | xauth -f /tmp/.docker.xauth nmerge - > /dev/null 2>&1")
 
 scanners = [

--- a/src/runner/opera_runner.rb
+++ b/src/runner/opera_runner.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "base_runner"
+
+# Executes a Chromium instance in a container
+class OperaRunner < BaseRunner
+  @built = false
+
+  def self.run(at)
+    unless @built
+      puts("Building container...")
+      system("docker build --build-arg user=$USER -t titryes/opera docker/opera > /dev/null 2>&1")
+      @built = true
+    end
+
+    start_container("opera", at)
+  end
+end

--- a/src/scanner/linux_scanner.rb
+++ b/src/scanner/linux_scanner.rb
@@ -3,6 +3,7 @@
 require_relative "base_scanner"
 require_relative "result/firefox_result"
 require_relative "result/chrome_result"
+require_relative "result/opera_result"
 
 # Scanner for GNU/Linux
 class LinuxScanner < BaseScanner
@@ -23,6 +24,8 @@ class LinuxScanner < BaseScanner
       Dir["#{path}home/*/.config/google-chrome"].map { |p| ChromeResult.new("Google Chrome", "Linux", p) },
       Dir["#{path}home/*/.config/google-chrome-beta"].map { |p| ChromeResult.new("Google Chrome Beta", "Linux", p) },
       Dir["#{path}home/*/.config/google-chrome-canary"].map { |p| ChromeResult.new("Google Chrome Canary", "Linux", p) },
+      # Opera
+      Dir["#{path}home/*/.config/opera"].map { |p| OperaResult.new("Opera", "Linux", p) }
     ].flatten
   end
 end

--- a/src/scanner/result/opera_result.rb
+++ b/src/scanner/result/opera_result.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "scan_result"
+require_relative "../../runner/opera_runner"
+
+# Found Opera or Opera GX
+class OperaResult < ScanResult
+  def copy(to)
+    to += "/.config/opera/"
+    FileUtils.mkdir_p(to)
+    FileUtils.copy_entry(@path, to)
+  end
+
+  def run(at)
+    copy(at)
+    OperaRunner.run(at)
+  end
+end

--- a/src/scanner/windows_scanner.rb
+++ b/src/scanner/windows_scanner.rb
@@ -20,6 +20,8 @@ class WindowsScanner < BaseScanner
       Dir["#{path}/Users/*/AppData/Local/Google/Chrome/User Data"].map { |p| ChromeResult.new("Chrome", "Windows", p) },
       Dir["#{path}/Users/*/AppData/Local/Google/Chrome Beta/User Data"].map { |p| ChromeResult.new("Chrome Beta", "Windows", p) },
       Dir["#{path}/Users/*/AppData/Local/Google/Chrome SxS/User Data"].map { |p| ChromeResult.new("Chrome Canary", "Windows", p) },
+      # Opera
+      Dir["#{path}/Users/*/AppData/Roaming/Opera Software/Opera Stable"].map { |p| OperaResult.new("Opera", "Windows", p) }
     ].flatten
   end
 end


### PR DESCRIPTION
Needed to create an Ubuntu-based container as it was not available for alpine.
Probably most other browsers besides Firefox and Chrome will require a Debian anyway.